### PR TITLE
fix(nilan-reader) Reconnect every 60s to the Nilan

### DIFF
--- a/dhw-ventilation/nilan-reader/src/main.rs
+++ b/dhw-ventilation/nilan-reader/src/main.rs
@@ -32,11 +32,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut context = sync::tcp::connect(options.address.unwrap_or(configuration.address))?;
-
     if options.into_thing {
-        thing::run(context, options.thing_port.or(configuration.thing_port));
+        thing::run(
+            options.address.unwrap_or(configuration.address),
+            options.thing_port.or(configuration.thing_port),
+        );
     } else {
+        let mut context = sync::tcp::connect(options.address.unwrap_or(configuration.address))?;
+
         match &options.format {
             Format::Text => println!("{:#?}", reader::read(&mut context)?),
             Format::Json => println!("{}", to_json(&reader::read(&mut context)?)?),


### PR DESCRIPTION
The connection is shutdown randomly after a couple of days for a
reason I ignore. So, let's update the values every 60s rather than 2s,
and re-connect for every reading.