### PR TITLE
fix(victron-reader) Display negative value for `Battery::ongoing_power` when discharging

### DIFF
--- a/electricity/victron-reader/src/unit.rs
+++ b/electricity/victron-reader/src/unit.rs
@@ -11,35 +11,42 @@ pub trait Unit {
     fn to_hertz(&self) -> Hertz;
 }
 
-impl Unit for u16 {
-    fn to_percent(&self) -> Percent {
-        Percent((*self as f32) / 10.0)
-    }
+macro_rules! impl_unit {
+    ($for:ty) => {
+        impl Unit for $for {
+            fn to_percent(&self) -> Percent {
+                Percent((*self as f32) / 10.0)
+            }
 
-    fn to_volt(&self) -> Volt {
-        Volt((*self as f32) / 100.0)
-    }
+            fn to_volt(&self) -> Volt {
+                Volt((*self as f32) / 100.0)
+            }
 
-    fn to_amp(&self) -> Amp {
-        Amp((*self) as f32)
-    }
+            fn to_amp(&self) -> Amp {
+                Amp((*self) as f32)
+            }
 
-    fn to_watt(&self) -> Watt {
-        Watt((*self) as f32)
-    }
+            fn to_watt(&self) -> Watt {
+                Watt((*self) as f32)
+            }
 
-    fn to_kwh(&self) -> KWh {
-        KWh(*self as f32)
-    }
+            fn to_kwh(&self) -> KWh {
+                KWh(*self as f32)
+            }
 
-    fn to_degree(&self) -> Degree {
-        Degree((*self as f32) / 10.0)
-    }
+            fn to_degree(&self) -> Degree {
+                Degree((*self as f32) / 10.0)
+            }
 
-    fn to_hertz(&self) -> Hertz {
-        Hertz((*self as f32) / 100.0)
-    }
+            fn to_hertz(&self) -> Hertz {
+                Hertz((*self as f32) / 100.0)
+            }
+        }
+    };
 }
+
+impl_unit!(u16);
+impl_unit!(i32);
 
 macro_rules! unit {
     ($name:ident, $display:expr) => {


### PR DESCRIPTION
When the battery is discharging, the battery power starts from 1 << 16
and goes backward. So to get the real value, we have to apply this
formula: - ( (1 << 16) - power ).